### PR TITLE
Allow RINs of format XXXX-XXXX-XXXX-XXX

### DIFF
--- a/custom_components/midas/config_flow.py
+++ b/custom_components/midas/config_flow.py
@@ -225,7 +225,7 @@ class MidasFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     def _test_rateids(self, rate_ids: list[str]) -> bool:
         """Test a list of rate ids to ensure they are valid."""
         for rid in rate_ids:
-            if re.match("^[A-Z]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}$", rid) is None:
+            if re.match("^[A-Z]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{3,4}$", rid) is None:
                 return True
         return False
 


### PR DESCRIPTION
Some RINs only have 3 characters in the last block instead of 4.