### PR TITLE
Don't let one stale rate id take down every other one

### DIFF
--- a/custom_components/midas/coordinator.py
+++ b/custom_components/midas/coordinator.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from datetime import timedelta
 from typing import TYPE_CHECKING
 
-from california_midasapi.exception import MidasAuthenticationException, MidasException
+from california_midasapi.exception import (
+    MidasAuthenticationException,
+    MidasException,
+    MidasNotFoundException,
+)
 from california_midasapi.types import RateInfo
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import issue_registry
@@ -59,8 +63,25 @@ class MidasDataUpdateCoordinator(DataUpdateCoordinator[dict[str, RateInfo]]):
                 # During rate switches, utilities may move active rates to the
                 #  historical table before they're actually over.
                 if len(tariffs) == 0:
-                    data[rid] = await self._client.async_get_historical_rate_data(rid)
-                    tariffs = data[rid].GetCurrentTariffs()
+                    # Deliberately wraps only the historical call. A rate id
+                    # that does not exist 404s on async_get_rate_data above,
+                    # and that must keep failing the update: widening this to
+                    # cover it would turn a mistyped rate id into a repair
+                    # telling the user their utility stopped publishing.
+                    try:
+                        data[rid] = await self._client.async_get_historical_rate_data(
+                            rid
+                        )
+                        tariffs = data[rid].GetCurrentTariffs()
+                    except MidasNotFoundException as exception:
+                        # A rate id with no data in the requested window answers
+                        # 404. That means "no tariffs for this rate id" rather
+                        # than a failed update, so fall through to the repair
+                        # below instead of failing every other rate id too.
+                        # Any other error still propagates.
+                        LOGGER.debug(
+                            f"Historical rates for {rid} unavailable: {exception}"
+                        )
 
                 # Check if there are any tariffs and issue error if not
                 if len(tariffs) == 0:

--- a/custom_components/midas/manifest.json
+++ b/custom_components/midas/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/MattDahEpic/ha-midas/issues",
   "requirements": [
-    "california-midasapi==2.1.0"
+    "california-midasapi==2.1.1"
   ],
   "single_config_entry": true,
   "version": "1.1.0"

--- a/custom_components/midas/manifest.json
+++ b/custom_components/midas/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/MattDahEpic/ha-midas/issues",
   "requirements": [
-    "california-midasapi==2.0.1"
+    "california-midasapi==2.1.0"
   ],
   "single_config_entry": true,
   "version": "1.1.0"

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,4 @@
 colorlog==6.10.1
 homeassistant==2026.1.0
 ruff==0.14.5
-california-midasapi==2.1.0
+california-midasapi==2.1.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,4 @@
 colorlog==6.10.1
 homeassistant==2026.1.0
 ruff==0.14.5
-california-midasapi==2.0.1
+california-midasapi==2.1.0

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,0 +1,230 @@
+"""Test the MIDAS data update coordinator."""
+
+# ignore errors that shouldn't matter in this test file
+# ruff: noqa: S101
+
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+import pytest
+from california_midasapi.exception import (
+    MidasAuthenticationException,
+    MidasCommunicationException,
+    MidasException,
+    MidasNotFoundException,
+)
+from california_midasapi.types import RateInfo, ValueInfoItem
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers import issue_registry as ir
+from homeassistant.helpers.update_coordinator import UpdateFailed
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.midas.api import IntegrationMidasApiClient
+from custom_components.midas.const import CONF_RATEIDS, DOMAIN
+from custom_components.midas.coordinator import MidasDataUpdateCoordinator
+from custom_components.midas.data import IntegrationMidasData
+
+STALE_RATE_ID = "USCA-TEST-STAL-0000"
+HEALTHY_RATE_ID = "USCA-TEST-GOOD-0000"
+
+
+def _rate_info(rate_id: str, *, with_tariff: bool) -> RateInfo:
+    """Build a RateInfo, optionally holding one currently active tariff."""
+    tariffs = []
+    if with_tariff:
+        # Span yesterday to tomorrow so the tariff is active whenever this runs.
+        # The two day spread also avoids GetEnd()'s next-day correction, which
+        # needs both an exactly-one-day range and DayStart == DayEnd.
+        today = datetime.now()  # noqa: DTZ005
+        tariffs.append(
+            ValueInfoItem(
+                ValueName="Test",
+                DateStart=(today - timedelta(days=1)).strftime("%Y-%m-%d"),
+                DateEnd=(today + timedelta(days=1)).strftime("%Y-%m-%d"),
+                DayStart="1",
+                DayEnd="3",
+                TimeStart="00:00:00",
+                TimeEnd="23:59:59",
+                Value=0.12345,
+                Unit="$/kWh",
+            )
+        )
+    return RateInfo(
+        RateID=rate_id,
+        SystemTime_UTC="",
+        RateName="Test Rate",
+        RateType="TOU",
+        Sector="Res",
+        API_Url="",
+        RatePlan_Url="",
+        EndUse="All",
+        AltRateName1="",
+        AltRateName2="",
+        SignalType="Electricity Rates",
+        Description="",
+        SignupCloseDate="",
+        ValueInformation=tariffs,
+    )
+
+
+async def _setup_with(
+    hass: HomeAssistant, rate_ids: list[str], historical_error: Exception
+) -> MockConfigEntry:
+    """Set up the integration where the historical lookup raises."""
+    entry = MockConfigEntry(
+        title="MIDAS",
+        domain=DOMAIN,
+        data={CONF_RATEIDS: rate_ids},
+    )
+    entry.add_to_hass(hass)
+
+    async def _get_rate_data(_self, rate_id: str) -> RateInfo:
+        # The stale rate id still answers, it just has no active tariffs.
+        return _rate_info(rate_id, with_tariff=rate_id != STALE_RATE_ID)
+
+    async def _get_historical_rate_data(_self, rate_id: str) -> RateInfo:
+        raise historical_error
+
+    with (
+        patch.object(IntegrationMidasApiClient, "async_get_rate_data", _get_rate_data),
+        patch.object(
+            IntegrationMidasApiClient,
+            "async_get_historical_rate_data",
+            _get_historical_rate_data,
+        ),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    return entry
+
+
+async def test_coordinator_stale_rate_id_does_not_break_the_others(
+    hass: HomeAssistant, issue_registry: ir.IssueRegistry
+) -> None:
+    """A rate id with no data must not take down the rest of the integration.
+
+    A rate id whose data has gone stale answers the historical endpoint with a
+    404 rather than an empty result. That used to escape the loop over every
+    configured rate id, so one stale utility made every sensor unavailable,
+    including sensors for rate ids that were perfectly healthy.
+    """
+    entry = await _setup_with(
+        hass,
+        [STALE_RATE_ID, HEALTHY_RATE_ID],
+        MidasNotFoundException("Requested data not found: 404"),
+    )
+
+    assert entry.state is ConfigEntryState.LOADED
+
+    coordinator = entry.runtime_data.coordinator
+    assert coordinator.last_update_success
+    # sensor.py indexes coordinator.data[rate_id] unguarded, so the stale key
+    # must survive rather than be dropped.
+    assert STALE_RATE_ID in coordinator.data
+    # And the healthy rate id was still fetched, despite being ordered after
+    # the stale one.
+    assert HEALTHY_RATE_ID in coordinator.data
+    assert len(coordinator.data[HEALTHY_RATE_ID].GetCurrentTariffs()) == 1
+
+    # And the stale one reports itself through the repair it already has.
+    assert issue_registry.async_get_issue(DOMAIN, f"no_tarrifs_{STALE_RATE_ID.lower()}")
+    assert not issue_registry.async_get_issue(
+        DOMAIN, f"no_tarrifs_{HEALTHY_RATE_ID.lower()}"
+    )
+
+
+@pytest.mark.parametrize(
+    ("error", "expected"),
+    [
+        (MidasAuthenticationException("Invalid credentials"), ConfigEntryAuthFailed),
+        (MidasCommunicationException("Connection reset"), UpdateFailed),
+        (MidasException("Error preforming request: 500"), UpdateFailed),
+    ],
+)
+async def test_coordinator_real_failures_are_not_swallowed(
+    hass: HomeAssistant,
+    error: Exception,
+    expected: type[Exception],
+) -> None:
+    """A real failure must still fail the update, not look like "no tariffs".
+
+    Only a 404 means "this rate id has no data". Anything else, including a
+    plain MidasException from a 500, has to reach the coordinator's own
+    handler so the update fails, rather than being reported as a successful
+    update plus a repair telling the user to contact their utility about a
+    rate id that is actually fine.
+
+    This drives the coordinator directly rather than going through setup,
+    because ConfigEntryAuthFailed makes Home Assistant start a reauth flow and
+    MidasFlowHandler has no reauth step to start.
+    """
+    entry = MockConfigEntry(
+        title="MIDAS",
+        domain=DOMAIN,
+        data={CONF_RATEIDS: [STALE_RATE_ID]},
+    )
+    entry.add_to_hass(hass)
+
+    coordinator = MidasDataUpdateCoordinator(
+        hass=hass, client=IntegrationMidasApiClient(hass=hass)
+    )
+    coordinator.config_entry = entry
+    entry.runtime_data = IntegrationMidasData(
+        coordinator=coordinator, rate_ids=[STALE_RATE_ID]
+    )
+
+    async def _get_rate_data(_self, rate_id: str) -> RateInfo:
+        return _rate_info(rate_id, with_tariff=False)
+
+    async def _get_historical_rate_data(_self, rate_id: str) -> RateInfo:
+        raise error
+
+    with (
+        patch.object(IntegrationMidasApiClient, "async_get_rate_data", _get_rate_data),
+        patch.object(
+            IntegrationMidasApiClient,
+            "async_get_historical_rate_data",
+            _get_historical_rate_data,
+        ),
+        pytest.raises(expected),
+    ):
+        await coordinator._async_update_data()  # noqa: SLF001
+
+
+async def test_coordinator_unknown_rate_id_still_fails_the_update(
+    hass: HomeAssistant,
+) -> None:
+    """A rate id that does not exist must fail loudly, not look like "no tariffs".
+
+    The API answers 404 for both "this rate id has no data in that window" and
+    "this rate id does not exist", so the two are only told apart by which call
+    raised. A nonexistent rate id 404s on the primary lookup, which is outside
+    the handler, and has to stay an UpdateFailed rather than becoming a repair
+    that blames the user's utility.
+    """
+    entry = MockConfigEntry(
+        title="MIDAS",
+        domain=DOMAIN,
+        data={CONF_RATEIDS: [STALE_RATE_ID]},
+    )
+    entry.add_to_hass(hass)
+
+    coordinator = MidasDataUpdateCoordinator(
+        hass=hass, client=IntegrationMidasApiClient(hass=hass)
+    )
+    coordinator.config_entry = entry
+    entry.runtime_data = IntegrationMidasData(
+        coordinator=coordinator, rate_ids=[STALE_RATE_ID]
+    )
+
+    async def _get_rate_data(_self, rate_id: str) -> RateInfo:
+        raise MidasNotFoundException(f"RIN not found: {rate_id}")
+
+    with (
+        patch.object(IntegrationMidasApiClient, "async_get_rate_data", _get_rate_data),
+        pytest.raises(UpdateFailed),
+    ):
+        await coordinator._async_update_data()  # noqa: SLF001

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -3,4 +3,3 @@
 # TODO test sensor goes unavailable when no data
 # TODO test update loop (sensor updates right on the next rate start)
 # TODO test that when no active tariffs the coordinator gets historical data
-# TODO test that when no active or historical tariffs a repair is raised


### PR DESCRIPTION
> [!NOTE]
> Draft until `california-midasapi` 2.1.0 is tagged and on PyPI. The Test job will be red until then, because `requirements_dev.txt` pins a version that does not exist yet. Lint and Validate pass.

### What happens

If one configured rate id stops receiving new data upstream, the whole integration fails and every sensor goes unavailable, including sensors for rate ids that are perfectly healthy.

I have an SCE delivery rate and a CPA generation rate configured. SCE stopped publishing to MIDAS after 2026-08-22 while CPA stayed current, and the integration failed setup with:

```
Failed setup, will retry: Error preforming request: 404 {"detail":"No historical data
found for RIN USCA-SCXX-0400-0000 between 2026-08-30 and 2026-09-01"}
```

Both sensors went unavailable, not just the SCE one, and the config entry never loaded at all.

### Why

The `try` in `_async_update_data` wraps the entire loop over `rate_ids`. When a rate id has no current tariffs it falls back to the historical endpoint, and for a stale rate id that endpoint answers 404 rather than returning an empty result. That escapes the loop and becomes `UpdateFailed` for the whole coordinator, so the `no_tariffs` repair right below it never runs, and no later rate id is fetched at all.

### The fix

Catch `MidasNotFoundException` around the historical call, so a 404 degrades to "no tariffs for this rate id" and falls through to the repair that already exists for exactly this case. Everything else still fails the update.

This is the typed exception you asked for, added in MattDahEpic/california-midasapi#5. It is also a real fix over my first version, which caught the base `MidasException` and re-raised the known subclasses: that swallowed a plain `MidasException` from a 500 and reported it as a successful update plus a repair blaming the user's utility. There is a test case for the 500 now.

The stale rate id's sensors still go unavailable and still raise the repair, matching what already happens when a rate id returns an empty `ValueInformation`. The difference is that the other rate ids keep working.

### Why the handler does not cover the primary call

Worth being explicit, because 404 is overloaded. Probing the live API:

| request | status | detail |
|---|---|---|
| real rate id, no data in the window | 404 | `No historical data found for RIN ... between ...` |
| well-formed but nonexistent rate id | 404 | `RIN not found: ...` |
| malformed rate id | 400 | `Invalid RIN format: ... Expected format: CCSS-DDEE-RRRR-LLLL` |

A nonexistent rate id 404s on `async_get_rate_data`, which is outside the handler, so a mistyped rate id still fails the update loudly instead of turning into a repair that blames the user's utility. That is call ordering rather than anything the exception type does, so `test_coordinator_unknown_rate_id_still_fails_the_update` pins it: widen the handler to cover the primary call and that test fails.

The consequence I am consciously leaving is that a rate id the utility fully retires 404s on the primary call and so still takes every other rate id down with it. Tolerating it there would leave `data[rid]` unset, and `sensor.py` indexes `coordinator.data[self._rate_id]` unguarded, so it needs more than a wider `except`.

### Tests

`tests/test_coordinator.py` puts a stale rate id ahead of a healthy one and asserts the entry still loads, the healthy rate id is still fetched, the stale key survives in `coordinator.data`, and the repair is raised for the stale one only. It fails on `main` and passes with the fix.

A parametrized test pins that auth, communication and a plain `MidasException` (a 500) all still fail the update, and a third test pins the primary-call behaviour above.

This covers the "when no active or historical tariffs a repair is raised" TODO in `tests/test_sensor.py`, so I removed that line.
